### PR TITLE
workflows: Add hardcoded `workdir` directives

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -7,17 +7,18 @@ If you have another data source or private data that needs to be formatted for
 the phylogenetic workflow, then you can use a similar workflow to curate your
 own data.
 
-## Run
+## Workflow Usage
 
-From within the `ingest` directory, run the workflow with:
+All workflows are expected to the be run from the top level pathogen repo directory.
+The default ingest workflow should be run with
 
 ```
-nextstrain build .
+nextstrain build . -s ingest/Snakefile
 ```
+This produces the default outputs of the ingest workflow:
 
-This produces a `results` directory with the following outputs:
-- sequences.fasta
-- metadata.tsv
+- metadata      = ingest/results/metadata.tsv
+- sequences     = ingest/results/sequences.fasta
 
 ## Defaults
 
@@ -31,6 +32,10 @@ options to override these default values.
 
 The rules directory contains separate Snakefiles (`*.smk`) as modules of the core ingest workflow.
 The modules of the workflow are in separate files to keep the main ingest [Snakefile](Snakefile) succinct and organized.
+
+The `workdir` is hardcoded to be the ingest directory so all filepaths for
+inputs/outputs should be relative to the ingest directory.
+
 Modules are all [included](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#includes)
 in the main Snakefile in the order that they are expected to run.
 

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -2,6 +2,8 @@
 This is the main ingest Snakefile that orchestrates the full ingest workflow
 and defines its default outputs.
 """
+# The workflow filepaths are written relative to this Snakefile's base directory
+workdir: workflow.current_basedir
 
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "defaults/config.yaml"

--- a/nextclade/README.md
+++ b/nextclade/README.md
@@ -6,6 +6,18 @@ The new standard would be to include the Nextclade workflow within the pathogen 
 This workflow is used to create the Nextclade datasets for this pathogen.
 All official Nextclade datasets are available at https://github.com/nextstrain/nextclade_data.
 
+## Workflow Usage
+
+All workflows are expected to the be run from the top level pathogen repo directory.
+The default nextclade workflow should be run with
+
+```
+nextstrain build . -s nextclade/Snakefile
+```
+This produces the default outputs of the nextclade workflow:
+
+- nextclade_dataset(s) = nextclade/datasets/<build_name>/*
+
 ## Defaults
 
 The defaults directory contains all of the default configurations for the Nextclade workflow.
@@ -17,7 +29,11 @@ options to override these default values.
 ## Snakefile and rules
 
 The rules directory contains separate Snakefiles (`*.smk`) as modules of the core Nextclade workflow.
-The modules of the workflow are in separate files to keep the main ingest [Snakefile](Snakefile) succinct and organized.
+The modules of the workflow are in separate files to keep the main nextclade [Snakefile](Snakefile) succinct and organized.
+
+The `workdir` is hardcoded to be the nextclade directory so all filepaths for
+inputs/outputs should be relative to the nextclade directory.
+
 Modules are all [included](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#includes)
 in the main Snakefile in the order that they are expected to run.
 

--- a/nextclade/Snakefile
+++ b/nextclade/Snakefile
@@ -2,6 +2,8 @@
 This is the main Nextclade Snakefile that orchestrates the workflow to produce
 a Nextclade dataset.
 """
+# The workflow filepaths are written relative to this Snakefile's base directory
+workdir: workflow.current_basedir
 
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "defaults/config.yaml"

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -3,6 +3,18 @@
 This workflow uses metadata and sequences to produce one or multiple [Nextstrain datasets][]
 that can be visualized in Auspice.
 
+## Workflow Usage
+
+All workflows are expected to the be run from the top level pathogen repo directory.
+The default phylogenetic workflow should be run with
+
+```
+nextstrain build . -s phylogenetic/Snakefile
+```
+This produces the default outputs of the phylogenetic workflow:
+
+- auspice_json(s) = auspice/*.json
+
 ## Data Requirements
 
 The core phylogenetic workflow will use metadata values as-is, so please do any
@@ -24,7 +36,11 @@ options to override these default values.
 ## Snakefile and rules
 
 The rules directory contains separate Snakefiles (`*.smk`) as modules of the core phylogenetic workflow.
-The modules of the workflow are in separate files to keep the main ingest [Snakefile](Snakefile) succinct and organized.
+The modules of the workflow are in separate files to keep the main phylogenetic [Snakefile](Snakefile) succinct and organized.
+
+The `workdir` is hardcoded to be the phylogenetic directory so all filepaths for
+inputs/outputs should be relative to the phylogenetic directory.
+
 Modules are all [included](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#includes)
 in the main Snakefile in the order that they are expected to run.
 

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -2,6 +2,8 @@
 This is the main phylogenetic Snakefile that orchestrates the full phylogenetic
 workflow and define its default output(s).
 """
+# The workflow filepaths are written relative to this Snakefile's base directory
+workdir: workflow.current_basedir
 
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "defaults/config.yaml"


### PR DESCRIPTION
Workflows must be run from the top level pathogen repo directory in order for them to have access to the `shared` directory in the containerized runtimes. After some external testing of different ways to invoke the workflows with the Nextstrain CLI¹, I've decided to add the hardcoded `workdir` directive in each workflow's main Snakefile.

Then the default workflows can be run with:
```
nextstrain build . -s phylogenetic/Snakefile
nextstrain build . -s ingest/Snakefile
nextstrain build . -s nextclade/Snakefile
```

With this uniform organization of workflows across pathogens, we can then move the Snakemake option to behind the scenes within the Nextclade CLI.

This will allow us to have a workflow manager agnostic option, such as:
```
nextstrain build --workflow phylogenetic .
```

¹ https://github.com/joverlee521/nextstrain-testing/blob/2650d10d1eb66a722469bcddda584bc1f50fae04/snakemake/shared-testing/current/README.md