### PR TITLE
Add top level nextstrain-pathogen.yaml file

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -9,16 +9,21 @@ own data.
 
 ## Workflow Usage
 
-All workflows are expected to the be run from the top level pathogen repo directory.
-The default ingest workflow should be run with
+The workflow can be run from the top level pathogen repo directory:
+```
+nextstrain build ingest
+```
 
+Alternatively, the workflow can also be run from within the ingest directory:
 ```
-nextstrain build . -s ingest/Snakefile
+cd ingest
+nextstrain build .
 ```
+
 This produces the default outputs of the ingest workflow:
 
-- metadata      = ingest/results/metadata.tsv
-- sequences     = ingest/results/sequences.fasta
+- metadata      = results/metadata.tsv
+- sequences     = results/sequences.fasta
 
 ## Defaults
 

--- a/nextclade/README.md
+++ b/nextclade/README.md
@@ -8,15 +8,20 @@ All official Nextclade datasets are available at https://github.com/nextstrain/n
 
 ## Workflow Usage
 
-All workflows are expected to the be run from the top level pathogen repo directory.
-The default nextclade workflow should be run with
+The workflow can be run from the top level pathogen repo directory:
+```
+nextstrain build nextclade
+```
 
+Alternatively, the workflow can also be run from within the nextclade directory:
 ```
-nextstrain build . -s nextclade/Snakefile
+cd nextclade
+nextstrain build .
 ```
+
 This produces the default outputs of the nextclade workflow:
 
-- nextclade_dataset(s) = nextclade/datasets/<build_name>/*
+- nextclade_dataset(s) = datasets/<build_name>/*
 
 ## Defaults
 

--- a/nextstrain-pathogen.yaml
+++ b/nextstrain-pathogen.yaml
@@ -1,0 +1,5 @@
+# This is currently an empty file to indicate the top level pathogen repo.
+# The inclusion of this file allows the Nextstrain CLI to run the
+# `nextstrain build` from any directory regardless of runtime.
+#
+# See https://github.com/nextstrain/cli/releases/tag/8.2.0 for more details.

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -5,12 +5,17 @@ that can be visualized in Auspice.
 
 ## Workflow Usage
 
-All workflows are expected to the be run from the top level pathogen repo directory.
-The default phylogenetic workflow should be run with
+The workflow can be run from the top level pathogen repo directory:
+```
+nextstrain build phylogenetic
+```
 
+Alternatively, the workflow can also be run from within the phylogenetic directory:
 ```
-nextstrain build . -s phylogenetic/Snakefile
+cd phylogenetic
+nextstrain build .
 ```
+
 This produces the default outputs of the phylogenetic workflow:
 
 - auspice_json(s) = auspice/*.json


### PR DESCRIPTION
## Description of proposed changes

This is currently an empty file to indicate the top level pathogen repo. The inclusion of this file allows the `nextstrain build` invocation to work from any directory regardless of runtime.

See https://github.com/nextstrain/cli/pull/355 for more details.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
