### PR TITLE
ingest/nextstrain-automation: Fix upload_to_s3

### DIFF
--- a/ingest/build-configs/nextstrain-automation/upload.smk
+++ b/ingest/build-configs/nextstrain-automation/upload.smk
@@ -20,7 +20,7 @@ send_notifications = (
 
 rule upload_to_s3:
     input:
-        file_to_upload=config["files_to_upload"][wildcards.remote_file],
+        file_to_upload=lambda wildcards: config["files_to_upload"][wildcards.remote_file],
     output:
         "results/upload/{remote_file}.upload",
     params:


### PR DESCRIPTION
Fixes error reported by @kimandrews on Slack:
```
$ nextstrain build ingest upload_all --configfile build-configs/nextstrain-automation/config.yaml -n
Config file defaults/config.yaml is extended by additional config specified via the command line.
NameError in file /nextstrain/build/ingest/build-configs/nextstrain-automation/upload.smk, line 23:
name 'wildcards' is not defined
```