### PR TITLE
Add .gitattibutes to force line endings to be LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Allow Git to decide if file is text or binary
+# Always use LF line endings even on Windows.
+* text=auto eol=lf


### PR DESCRIPTION
Nextstrain pathogen repositories should be standardized include `.gitattributes` for force line endings to be LF.

We've run into issues in the past with Windows users running into workflow errors because of Windows line endings (CRLF):

https://github.com/nextstrain/mpox/commit/def0a713ae699fc313b549840e7f41f3033e3467 
https://github.com/nextstrain/seasonal-flu/commit/202263aecf47e1906875bd2d2e80d7b0c82039cd


