### PR TITLE
ingest: Provide target for raw metadata from NCBI Datasets

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -25,6 +25,18 @@ This produces the default outputs of the ingest workflow:
 - metadata      = results/metadata.tsv
 - sequences     = results/sequences.fasta
 
+### Dumping the full raw metadata from NCBI Datasets
+
+The workflow has a target for dumping the full raw metadata from NCBI Datasets.
+
+```
+nextstrain build ingest dump_ncbi_dataset_report
+```
+
+This will produce the file `ingest/data/ncbi_dataset_report_raw.tsv`,
+which you can inspect to determine what fields and data to use if you want to
+configure the workflow for your pathogen.
+
 ## Defaults
 
 The defaults directory contains all of the default configurations for the ingest workflow.

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -52,6 +52,20 @@ rule fetch_ncbi_dataset_package:
             --filename {output.dataset_package}
         """
 
+# Note: This rule is not part of the default workflow!
+# It is intended to be used as a specific target for users to be able
+# to inspect and explore the full raw metadata from NCBI Datasets.
+rule dump_ncbi_dataset_report:
+    input:
+        dataset_package="data/ncbi_dataset.zip",
+    output:
+        ncbi_dataset_tsv="data/ncbi_dataset_report_raw.tsv",
+    shell:
+        """
+        dataformat tsv virus-genome \
+            --package {input.dataset_package} > {output.ncbi_dataset_tsv}
+        """
+
 
 rule extract_ncbi_dataset_sequences:
     input:


### PR DESCRIPTION
Provides an easy way for first time users to get the full
uncurated metadata from NCBI Datasets commands by running the
ingest workflow with the specified target `dump_ncbi_dataset_report`.
They can then inspect and explore the raw data to determine if they
want to configure the workflow to use additional fields from NCBI.

The rule is added to `fetch_from_ncbi.smk` to make it easy to run
without additional configs. Note that it is not run as part of the
default workflow and only intended to be used as a specified target.

Prompted by @jameshadfield in review of the tutorial¹ and
resolves https://github.com/nextstrain/pathogen-repo-guide/issues/30.

¹ https://github.com/nextstrain/docs.nextstrain.org/pull/195 (comment)