### PR TITLE
ingest: Create new accession field without version

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -46,6 +46,7 @@ curate:
   # This is the first step in the pipeline, so any references to field names in the configs below should use the new field names
   field_map:
     accession: accession
+    accession_version: accession_version
     sourcedb: database
     sra-accs: sra_accessions
     isolate-lineage: strain
@@ -100,6 +101,7 @@ curate:
   # The list of metadata columns to keep in the final output of the curation pipeline.
   metadata_columns: [
     "accession",
+    "accession_version",
     "strain",
     "date",
     "region",

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -96,9 +96,11 @@ rule format_ncbi_dataset_report:
             --package {input.dataset_package} \
             --fields {params.ncbi_datasets_fields:q} \
             --elide-header \
+            | csvtk fix-quotes -Ht \
             | csvtk add-header -t -l -n {params.ncbi_datasets_fields:q} \
             | csvtk rename -t -f accession -n accession_version \
-            | csvtk -tl mutate -f accession_version -n accession -p "^(.+?)\." \
+            | csvtk -t mutate -f accession_version -n accession -p "^(.+?)\." \
+            | csvtk del-quotes -t \
             | tsv-select -H -f accession --rest last \
             > {output.ncbi_dataset_tsv}
         """

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -97,6 +97,9 @@ rule format_ncbi_dataset_report:
             --fields {params.ncbi_datasets_fields:q} \
             --elide-header \
             | csvtk add-header -t -l -n {params.ncbi_datasets_fields:q} \
+            | csvtk rename -t -f accession -n accession_version \
+            | csvtk -tl mutate -f accession_version -n accession -p "^(.+?)\." \
+            | tsv-select -H -f accession --rest last \
             > {output.ncbi_dataset_tsv}
         """
 
@@ -120,7 +123,7 @@ rule format_ncbi_datasets_ndjson:
         augur curate passthru \
             --metadata {input.ncbi_dataset_tsv} \
             --fasta {input.ncbi_dataset_sequences} \
-            --seq-id-column accession \
+            --seq-id-column accession_version \
             --seq-field sequence \
             --unmatched-reporting warn \
             --duplicate-reporting warn \


### PR DESCRIPTION
Resolves https://github.com/nextstrain/pathogen-repo-guide/issues/39

Create a new accession field without the version number so that annotations do not need to be updated when the version number is updated.

## Related issue(s)

Related to https://github.com/nextstrain/measles/issues/24

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
