### PR TITLE
Adds a recommended `is_lab_host` column to the ingested metadata.tsv file

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -26,6 +26,7 @@ ncbi_datasets_fields:
   - update-date
   - length
   - host-name
+  - is-lab-host
   - isolate-lineage-source
   - biosample-acc
   - submitter-names
@@ -57,6 +58,7 @@ curate:
     update-date: date_updated
     length: length
     host-name: host
+    is-lab-host: is_lab_host
     isolate-lineage-source: sample_type
     biosample-acc: biosample_accessions
     submitter-names: authors
@@ -112,6 +114,7 @@ curate:
     "location",
     "length",
     "host",
+    "is_lab_host",
     "date_released",
     "date_updated",
     "sra_accessions",


### PR DESCRIPTION
## Description of proposed changes

Enables filtering out lab-host strains to focus on real-time genomic surveillance strains. I've needed to filter out `PAT` and other lab-host strains in 
* [dengue](https://github.com/nextstrain/dengue/commit/af38fb000155029d6a3a4f8f5fee7055316dfd5a)
* [lassa](https://github.com/nextstrain/lassa/pull/25)
* and again in WNV

I'm adding the `is_lab_host` column to the `pathogen-repo-guide` since we usually want to be able to filter these out of real-time phylogenetic trees, and so I may one-day stop forgetting to add this column...

## Related issue(s)
Resolves https://github.com/nextstrain/pathogen-repo-guide/issues/60

## Checklist

- [x] Checks pass

