### PR TITLE
ingest: Switch to `full_authors` and `authors` fields

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -61,7 +61,7 @@ curate:
     is-lab-host: is_lab_host
     isolate-lineage-source: sample_type
     biosample-acc: biosample_accessions
-    submitter-names: authors
+    submitter-names: full_authors
     submitter-affiliation: institution
     submitter-country: submitter_country
   # Standardized strain name regex
@@ -88,11 +88,11 @@ curate:
       "los", "nad", "of", "op", "sur", "the", "y"
     ]
   # Metadata field that contains the list of authors associated with the sequence
-  authors_field: "authors"
+  authors_field: "full_authors"
   # Default value to use if the authors field is empty
   authors_default_value: "?"
   # Name to use for the generated abbreviated authors field
-  abbr_authors_field: "abbr_authors"
+  abbr_authors_field: "authors"
   # Path to the manual annotations file
   # The path should be relative to the ingest directory
   annotations: "defaults/annotations.tsv"
@@ -119,6 +119,6 @@ curate:
     "date_updated",
     "sra_accessions",
     "authors",
-    "abbr_authors",
+    "full_authors",
     "institution",
   ]


### PR DESCRIPTION
## Description of proposed changes

Switch `authors` to `full_authors` and `abbr_authors` to `authors` so that the abbreviated author field is used by `augur export` in the phylogenetic workflow.

Making this the default in pathogen repos until we get around to https://github.com/nextstrain/augur/issues/1685. 

## Related issue(s)

Similar to changes in https://github.com/nextstrain/mpox/pull/295.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
