### PR TITLE
ingest: properly handle TSVs with `csvtk`

### DIFF
--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -126,6 +126,6 @@ rule subset_metadata:
         metadata_fields=",".join(config["curate"]["metadata_columns"]),
     shell:
         """
-        tsv-select -H -f {params.metadata_fields} \
+        csvtk cut -t -f {params.metadata_fields} \
             {input.metadata} > {output.subset_metadata}
         """

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -97,11 +97,9 @@ rule format_ncbi_dataset_report:
             --fields {params.ncbi_datasets_fields:q} \
             --elide-header \
             | csvtk fix-quotes -Ht \
-            | csvtk add-header -t -l -n {params.ncbi_datasets_fields:q} \
+            | csvtk add-header -t -n {params.ncbi_datasets_fields:q} \
             | csvtk rename -t -f accession -n accession_version \
-            | csvtk -t mutate -f accession_version -n accession -p "^(.+?)\." \
-            | csvtk del-quotes -t \
-            | tsv-select -H -f accession --rest last \
+            | csvtk -t mutate -f accession_version -n accession -p "^(.+?)\." --at 1 \
             > {output.ncbi_dataset_tsv}
         """
 

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -77,7 +77,7 @@ rule nextclade_metadata:
             --id-column {params.nextclade_id_field:q} \
             --field-map {params.nextclade_field_map:q} \
             --output-metadata - \
-        | tsv-select --header --fields {params.nextclade_fields:q} \
+        | csvtk cut -t --fields {params.nextclade_fields:q} \
         > {output.nextclade_metadata:q}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Following Nextstrain data format docs to update handling of TSVs with `csvtk`.¹ Instead of going through extra `csv2tsv`/`csvtk fix-quotes` commands, just replace `tsv-select` with `csvtk`. Note that NCBI uses IANA TSVs,² so the `dataformat` output must go through `csvtk fix-quotes` to be properly quoted as CSV-like TSVs.

- `tsv-select` to subset columns is directly replaced with `csvtk cut -t`.
- `tsv-select` to reorder columns is replaced with `csvtk mutate --at 1` to insert the new `accession` column as the first column.

¹ <https://docs.nextstrain.org/en/latest/reference/data-formats.html#id1> 
² <https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/file-formats/metadata-files/about-json-and-tabular/>

## Related issue(s)

Resolves https://github.com/nextstrain/pathogen-repo-guide/issues/66

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
