### PR TITLE
Write config to file

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -26,6 +26,7 @@ rule all:
 # If there are build-specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build-specific rules.
+include: "rules/config.smk"
 include: "rules/fetch_from_ncbi.smk"
 include: "rules/curate.smk"
 

--- a/ingest/rules/config.smk
+++ b/ingest/rules/config.smk
@@ -1,0 +1,13 @@
+"""
+This part of the workflow deals with configuration.
+
+OUTPUTS:
+
+    results/run_config.yaml
+
+The output is represents the fully merged config dict that is used by Snakemake
+during the workflow run. It should _not_ be manually edited because the
+workflow will automatically overwrite it on every run.
+"""
+
+write_config("results/run_config.yaml")

--- a/nextclade/Snakefile
+++ b/nextclade/Snakefile
@@ -27,6 +27,7 @@ rule all:
 # If there are build specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build specific rules.
+include: "rules/config.smk"
 include: "rules/preprocess.smk"
 include: "rules/prepare_sequences.smk"
 include: "rules/construct_phylogeny.smk"

--- a/nextclade/rules/config.smk
+++ b/nextclade/rules/config.smk
@@ -1,0 +1,13 @@
+"""
+This part of the workflow deals with configuration.
+
+OUTPUTS:
+
+    results/run_config.yaml
+
+The output is represents the fully merged config dict that is used by Snakemake
+during the workflow run. It should _not_ be manually edited because the
+workflow will automatically overwrite it on every run.
+"""
+
+write_config("results/run_config.yaml")

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -34,6 +34,7 @@ include: "../shared/vendored/snakemake/remote_files.smk"
 # If there are build specific customizations, they should be added with the
 # custom_rules imported below to ensure that the core workflow is not complicated
 # by build specific rules.
+include: "rules/config.smk"
 include: "rules/merge_inputs.smk"
 include: "rules/prepare_sequences.smk"
 include: "rules/construct_phylogeny.smk"

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -1,0 +1,13 @@
+"""
+This part of the workflow deals with configuration.
+
+OUTPUTS:
+
+    results/run_config.yaml
+
+The output is represents the fully merged config dict that is used by Snakemake
+during the workflow run. It should _not_ be manually edited because the
+workflow will automatically overwrite it on every run.
+"""
+
+write_config("results/run_config.yaml")

--- a/shared/vendored/.github/workflows/pre-commit.yaml
+++ b/shared/vendored/.github/workflows/pre-commit.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - uses: pre-commit/action@v3.0.1

--- a/shared/vendored/.gitrepo
+++ b/shared/vendored/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/nextstrain/shared
 	branch = main
-	commit = 2d063cf2bae0cfc91d70fda2c36f1451656e5757
-	parent = f3c792c2a4d6ebec3a70c3d65b61258208789c67
+	commit = bfbbb6875b084e22920712d89704ccb259f8950e
+	parent = cb87e1ac0e6c98d08bab76b954309aeb3bae889b
 	method = merge
 	cmdver = 0.4.6

--- a/shared/vendored/README.md
+++ b/shared/vendored/README.md
@@ -22,7 +22,7 @@ Then add the latest shared scripts to the pathogen repo by running:
 git subrepo clone https://github.com/nextstrain/shared shared/vendored
 ```
 
-Any future updates of sahred scripts can be pulled in with:
+Any future updates of shared scripts can be pulled in with:
 
 ```
 git subrepo pull shared/vendored
@@ -123,7 +123,7 @@ Potential Nextstrain CLI scripts
 
 Snakemake workflow functions that are shared across many pathogen workflows that don’t really belong in any of our existing tools.
 
-- [config.smk](snakemake/config.smk) - Shared functions for parsing workflow configs.
+- [config.smk](snakemake/config.smk) - Shared functions for handling workflow configs.
 - [remote_files.smk](snakemake/remote_files.smk) - Exposes the `path_or_url` function which will use Snakemake's storage plugins to download/upload files to remote providers as needed.
 
 

--- a/shared/vendored/snakemake/config.smk
+++ b/shared/vendored/snakemake/config.smk
@@ -1,8 +1,10 @@
 """
-Shared functions to be used within a Snakemake workflow for parsing
+Shared functions to be used within a Snakemake workflow for handling
 workflow configs.
 """
-import os.path
+import os
+import sys
+import yaml
 from collections.abc import Callable
 from snakemake.io import Wildcards
 from typing import Optional
@@ -11,6 +13,74 @@ from textwrap import dedent, indent
 
 class InvalidConfigError(Exception):
     pass
+
+
+def resolve_filepaths(filepaths):
+    """
+    Update filepaths in-place by passing them through resolve_config_path().
+
+    `filepaths` must be a list of key tuples representing filepaths in config.
+    Use "*" as a a key-expansion placeholder: it means "iterate over all keys at
+    this level".
+    """
+    global config
+
+    for keys in filepaths:
+        _traverse(config, keys, traversed_keys=[])
+
+
+def _traverse(config_section, keys, traversed_keys):
+    """
+    Recursively walk through the config following a list of keys.
+
+    When the final key is reached, the value is updated in place.
+    """
+    key = keys[0]
+    remaining_keys = keys[1:]
+
+    if key == "*":
+        for key in config_section:
+            if len(remaining_keys) == 0:
+                _update_value_inplace(config_section, key, traversed_keys=traversed_keys + [f'* ({key})'])
+            else:
+                if isinstance(config_section[key], dict):
+                    _traverse(config_section[key], remaining_keys, traversed_keys=traversed_keys + [f'* ({key})'])
+                else:
+                    # Value for key is not a dict
+                    # Leave as-is - this may be valid config value.
+                    continue
+    elif key in config_section:
+        if len(remaining_keys) == 0:
+            _update_value_inplace(config_section, key, traversed_keys=traversed_keys + [key])
+        else:
+            _traverse(config_section[key], remaining_keys, traversed_keys=traversed_keys + [key])
+    else:
+        # Key not present in config section
+        # Ignore - this may be an optional parameter.
+        return
+
+
+def _update_value_inplace(config_section, key, traversed_keys):
+    """
+    Update the value at 'config_section[key]' with resolve_config_path().
+
+    resolve_config_path() returns a callable which has the ability to replace
+    {var} in filepath strings. This was originally designed to support Snakemake
+    wildcards, but those are not applicable here since this code is not running
+    in the context of a Snakemake rule. It is unused here - the callable is
+    given an empty dict.
+    """
+    value = config_section[key]
+    traversed = ' → '.join(repr(key) for key in traversed_keys)
+    if isinstance(value, list):
+        for path in value:
+            assert isinstance(path, str), f"ERROR: Expected string but got {type(path).__name__} at {traversed}."
+        new_value = [resolve_config_path(path)({}) for path in value]
+    else:
+        assert isinstance(value, str), f"ERROR: Expected string but got {type(value).__name__} at {traversed}."
+        new_value = resolve_config_path(value)({})
+    config_section[key] = new_value
+    print(f"Resolved {value!r} to {new_value!r}.", file=sys.stderr)
 
 
 def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callable[[Wildcards], str]:
@@ -75,3 +145,17 @@ def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callab
             """), " " * 4))
 
     return _resolve_config_path
+
+
+def write_config(path):
+    """
+    Write Snakemake's 'config' variable to a file.
+    """
+    global config
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    with open(path, 'w') as f:
+        yaml.dump(config, f, sort_keys=False)
+
+    print(f"Saved current run config to {path!r}.", file=sys.stderr)


### PR DESCRIPTION
## Description of proposed changes

Made the same change across all workflows to write the Snakemake config to an output file with the shared `write_config` function. Calling the function on a per-workflow basis to leave room for workflow specific config manipulation _before_ writing the config.

## Related issue(s)

https://github.com/nextstrain/pathogen-repo-guide/issues/18

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
